### PR TITLE
mediatek/filogic: crypto/safexcel add support

### DIFF
--- a/target/linux/mediatek/patches-6.6/870-crypto-safexcel-add-eip197-inside-secure-support.patch
+++ b/target/linux/mediatek/patches-6.6/870-crypto-safexcel-add-eip197-inside-secure-support.patch
@@ -1,0 +1,69 @@
+--- a/drivers/crypto/inside-secure/safexcel.c
++++ b/drivers/crypto/inside-secure/safexcel.c
+@@ -455,6 +455,9 @@ retry_fw:
+ 
+ 	ipuesz = eip197_write_firmware(priv, fw[FW_IPUE]);
+ 
++	for (j = 0; j < i; j++)
++		release_firmware(fw[j]);
++
+ 	if (eip197_start_firmware(priv, ipuesz, ifppsz, minifw)) {
+ 		dev_dbg(priv->dev, "Firmware loaded successfully\n");
+ 		return 0;
+@@ -605,6 +608,11 @@ static int safexcel_hw_init(struct safex
+ 	 */
+ 	if (priv->flags & SAFEXCEL_HW_EIP197) {
+ 		val = readl(EIP197_HIA_AIC(priv) + EIP197_HIA_MST_CTRL);
++		/* Clear axi_burst_size and rx_burst_size */
++		val &= 0xffffff00;
++		/* Set axi_burst_size = 3, rx_burst_size = 3 */
++		val |= EIP197_MST_CTRL_RD_CACHE(3);
++		val |= EIP197_MST_CTRL_WD_CACHE(3); 
+ 		val |= EIP197_MST_CTRL_TX_MAX_CMD(5);
+ 		writel(val, EIP197_HIA_AIC(priv) + EIP197_HIA_MST_CTRL);
+ 	}
+@@ -805,6 +813,12 @@ static int safexcel_hw_init(struct safex
+ 			return ret;
+ 	}
+ 
++	/* Allow clocks to be forced on for EIP197 */
++	if (priv->flags & SAFEXCEL_HW_EIP197) {
++		writel(0xffffffff, EIP197_HIA_GEN_CFG(priv) + EIP197_FORCE_CLOCK_ON);
++		writel(0xffffffff, EIP197_HIA_GEN_CFG(priv) + EIP197_FORCE_CLOCK_ON2);
++	}
++
+ 	return safexcel_hw_setup_cdesc_rings(priv) ?:
+ 	       safexcel_hw_setup_rdesc_rings(priv) ?:
+ 	       0;
+@@ -1746,6 +1760,7 @@ static int safexcel_probe(struct platfor
+ {
+ 	struct device *dev = &pdev->dev;
+ 	struct safexcel_crypto_priv *priv;
++	struct resource *res;
+ 	int ret;
+ 
+ 	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
+@@ -1757,7 +1772,11 @@ static int safexcel_probe(struct platfor
+ 
+ 	platform_set_drvdata(pdev, priv);
+ 
+-	priv->base = devm_platform_ioremap_resource(pdev, 0);
++	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
++	if (!res)
++		return -EINVAL;
++
++	priv->base = devm_ioremap(dev, res->start, resource_size(res));
+ 	if (IS_ERR(priv->base)) {
+ 		dev_err(dev, "failed to get resource\n");
+ 		return PTR_ERR(priv->base);
+--- a/drivers/crypto/inside-secure/safexcel.h
++++ b/drivers/crypto/inside-secure/safexcel.h
+@@ -189,6 +189,8 @@
+ #define EIP197_PE_DEBUG(n)			(0x1ff4 + (0x2000 * (n)))
+ #define EIP197_PE_OPTIONS(n)			(0x1ff8 + (0x2000 * (n)))
+ #define EIP197_PE_VERSION(n)			(0x1ffc + (0x2000 * (n)))
++#define EIP197_FORCE_CLOCK_ON2			0xffd8
++#define EIP197_FORCE_CLOCK_ON			0xffe8
+ #define EIP197_MST_CTRL				0xfff4
+ #define EIP197_OPTIONS				0xfff8
+ #define EIP197_VERSION				0xfffc


### PR DESCRIPTION
The filogic banana-rpi4 has a crypto module that makes use of safexcel/eip197 to date the module doesn't load.

Refactored 5.4 patch from Mediatek - https://git01.mediatek.com/plugins/gitiles/openwrt/feeds/mtk-openwrt-feeds/+/refs/heads/master/21.02/files/target/linux/mediatek/patches-5.4/999-2706-crypto-add-eip197-inside-secure-support.patch

Changes to base driver code

. Release Firmware Loop:
+ for (j = 0; j < i; j++)
+     release_firmware(fw[j]);

After writing firmware, the added loop releases the allocated firmware resources. This addition helps in reducing memory usage and potential resource leaks by ensuring that firmware that is no longer needed is freed properly

. AXI Burst Size and Cache Settings:
+ /* Clear axi_burst_size and rx_burst_size */
+ val &= 0xffffff00;
+ /* Set axi_burst_size = 3, rx_burst_size = 3 */
+ val |= EIP197_MST_CTRL_RD_CACHE(3);
+ val |= EIP197_MST_CTRL_WD_CACHE(3);

The added lines clear existing burst size settings and then set both axi_burst_size and rx_burst_size to 3. This change aims to optimize data transactions by configuring suitable burst sizes, potentially improving performance (tbc)

. Clock Forcing Mechanism:

+ /* Allow clocks to be forced on for EIP197 */
+ if (priv->flags & SAFEXCEL_HW_EIP197) {
+     writel(0xffffffff, EIP197_HIA_GEN_CFG(priv) + EIP197_FORCE_CLOCK_ON);
+     writel(0xffffffff, EIP197_HIA_GEN_CFG(priv) + EIP197_FORCE_CLOCK_ON2);
+ }

Forcing clocks on for the EIP197 is introduced. This ensures that the clocks remain active, likely improving stability and reliability in certain hardware environments where clock gating might have caused issues.

. Resource Acquisition and Mapping:

+ struct resource *res; ...
+ res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+ if (!res)
+     return -EINVAL;
+ priv->base = devm_ioremap(dev, res->start, resource_size(res));
- priv->base = devm_platform_ioremap_resource(pdev, 0);

The previous resource mapping (devm_platform_ioremap_resource) is replaced with manual acquisition (platform_get_resource) and mapping (devm_ioremap). This provides finer control over the resource, allowing for better error handling and making it possible to check the validity of the resource before proceeding.

New Macros for Clock Control:
+ #define EIP197_FORCE_CLOCK_ON2  0xffd8
+ #define EIP197_FORCE_CLOCK_ON   0xffe8

Two new macro definitions, EIP197_FORCE_CLOCK_ON and EIP197_FORCE_CLOCK_ON2, are introduced. These are used to address the corresponding registers that manage the forced clocking mechanism.

Tested on the banana rpi4

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
